### PR TITLE
Fix position of flash alerts on landing page

### DIFF
--- a/lib/mindwendel_web/templates/static_page/kits_home.html.heex
+++ b/lib/mindwendel_web/templates/static_page/kits_home.html.heex
@@ -48,10 +48,11 @@
 
     <div class="row g-0 h-100">
       <div id="content" class="container w-90 d-flex align-content-center flex-wrap">
-        <p class="alert alert-secondary" role="alert"><%= get_flash(@conn, :info) %></p>
-        <p class="alert alert-danger" role="alert"><%= get_flash(@conn, :error) %></p>
-
         <div id="call-to-action-block">
+
+          <p class="alert alert-secondary" role="alert"><%= get_flash(@conn, :info) %></p>
+          <p class="alert alert-danger" role="alert"><%= get_flash(@conn, :error) %></p>
+
           <h1 class="fw-bold">
             <%= link "mindwendel", to: "/", title: "mindwendel", class: "text-decoration-none" %>
           </h1>


### PR DESCRIPTION
## Further Notes

- The flash alerts have been misplaced after the redesign of the website, see following screenshot

![image](https://user-images.githubusercontent.com/592424/222946156-761d9978-a460-4e26-bb79-927f91f9d061.png)


## New Features / Enhancements

- [x] Fix position of flash alert

<img width="1840" alt="image" src="https://user-images.githubusercontent.com/592424/222946070-049e26cf-bb77-4de2-9b25-7e2af82b814e.png">

## After Merge Checklist
