### PR TITLE
bug: fix flash alerts after phoenix 1.7 upgrade

### DIFF
--- a/lib/mindwendel_web.ex
+++ b/lib/mindwendel_web.ex
@@ -35,7 +35,7 @@ defmodule MindwendelWeb do
 
       # Import convenience functions from controllers
       import Phoenix.Controller,
-        only: [get_flash: 1, get_flash: 2, view_module: 1, view_template: 1]
+        only: [view_module: 1, view_template: 1]
 
       # Include shared imports and aliases for views
       unquote(view_helpers())

--- a/lib/mindwendel_web/templates/layout/app.html.heex
+++ b/lib/mindwendel_web/templates/layout/app.html.heex
@@ -1,5 +1,9 @@
 <main role="main" class="container">
-  <p class="alert alert-secondary" role="alert"><%= Phoenix.Flash.get(@flash, :info) %></p>
-  <p class="alert alert-danger" role="alert"><%= Phoenix.Flash.get(@flash, :error) %></p>
+  <%= if Phoenix.Flash.get(@flash, :info) do %>
+    <p class="alert alert-secondary" role="alert"><%= Phoenix.Flash.get(@flash, :info) %></p>
+  <% end %>
+  <%= if Phoenix.Flash.get(@flash, :error) do %>
+    <p class="alert alert-danger" role="alert"><%= Phoenix.Flash.get(@flash, :error) %></p>
+  <% end %>
   <%= @inner_content %>
 </main>

--- a/lib/mindwendel_web/templates/layout/live.html.heex
+++ b/lib/mindwendel_web/templates/layout/live.html.heex
@@ -1,11 +1,13 @@
 <main role="main" class="container" id="main-container">
-  <p class="alert alert-secondary" role="alert" phx-click="lv:clear-flash" phx-value-key="info">
-    <%= live_flash(@flash, :info) %>
-  </p>
-
-  <p class="alert alert-danger" role="alert" phx-click="lv:clear-flash" phx-value-key="error">
-    <%= live_flash(@flash, :error) %>
-  </p>
-
+  <%= if live_flash(@flash, :info) do %>
+    <p class="alert alert-secondary" role="alert" phx-click="lv:clear-flash" phx-value-key="info">
+      <%= live_flash(@flash, :info) %>
+    </p>
+  <% end %>
+  <%= if live_flash(@flash, :error) do %>
+    <p class="alert alert-danger" role="alert" phx-click="lv:clear-flash" phx-value-key="error">
+      <%= live_flash(@flash, :error) %>
+    </p>
+  <% end %>
   <%= @inner_content %>
 </main>

--- a/lib/mindwendel_web/templates/static_page/kits_home.html.heex
+++ b/lib/mindwendel_web/templates/static_page/kits_home.html.heex
@@ -96,8 +96,16 @@
     <div class="row g-0 h-100">
       <div id="content" class="container w-90 d-flex align-content-center flex-wrap">
         <div id="call-to-action-block">
-          <p class="alert alert-secondary" role="alert"><%= get_flash(@conn, :info) %></p>
-          <p class="alert alert-danger" role="alert"><%= get_flash(@conn, :error) %></p>
+          <%= if Phoenix.Flash.get(@flash, :info) do %>
+            <p class="alert alert-secondary" role="alert">
+              <%= Phoenix.Flash.get(@flash, :info) %>
+            </p>
+          <% end %>
+          <%= if Phoenix.Flash.get(@flash, :error) do %>
+            <p class="alert alert-danger" role="alert">
+              <%= Phoenix.Flash.get(@flash, :error) %>
+            </p>
+          <% end %>
 
           <h1 class="fw-bold">
             <%= link("mindwendel", to: "/", title: "mindwendel", class: "text-decoration-none") %>


### PR DESCRIPTION
## Further Notes
Checks if flash message is empty before rendering the alert boxes.
